### PR TITLE
Update package.json by adding keywords

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,5 +9,12 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/stevenkaspar/gatsby-plugin-ngrok-tunneling.git"
-  }
+  },
+  "keywords": [
+    "gatsby",
+    "gatsby-plugin",
+    "ngrok",
+    "tunneling",
+    "plugin"
+  ]
 }


### PR DESCRIPTION
## Changes
* Added `gatsby`, `gatsby-plugin`, `ngrok`, `tunneling`, `plugin` keywords to package.json
## Description
Hello. I found that the `package.json` file does not contain the keywords. In particular I added the keyword `gatsby-plugin`. This change will [submit the plugin to the Gatsby Plugin Library](https://www.gatsbyjs.org/contributing/submit-to-plugin-library/). You can also go to gatsbyjs/gatsby#14013 for more detailed information. Thanks.